### PR TITLE
Bugfix: Handle filenames correctly and match TVDB strings

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="plugin.video.sosac.ph" name="Sosáč" provider-name="Blue ClouDragon" version="2.0.0">
+<addon id="plugin.video.sosac.ph" name="Sosáč" provider-name="Blue ClouDragon" version="2.1.0">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.common.plugin.cache" version="2.5.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,3 +2,6 @@
 - Upgrade python version to 3.0.0
 - Integrate resolver library to addon structure
 - Upgrade and Fix features for Kodi 19 version
+[B]2.0.1:[/B] 17. 08. 2023
+- Fixed the `normalize_filename` function in `sutils.py` to handle byte-type filenames. This resolved a TypeError when checking characters against valid filename characters.
+- Resolved an issue in the `getTVDB` function where a byte-like object was passed to a regular expression search. Added decoding to ensure the name variable is a string.

--- a/resources/lib/sutils.py
+++ b/resources/lib/sutils.py
@@ -45,7 +45,7 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
         validFilenameChars = "-_.() %s%s" % (string.ascii_letters, string.digits)
         if (validChars is not None):
             validFilenameChars = validChars
-        cleanedFilename = self.encode(name)
+        cleanedFilename = self.encode(name).decode('ascii')
         return ''.join(c for c in cleanedFilename if c in validFilenameChars)
 
     def service(self):
@@ -142,7 +142,7 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
             tvid = re.search('<id>(\d+)</id>', data)
             if tvid:
                 return tvid.group(1)
-        shortname = re.search('(.+) (\(\d{4}\))', name).group(1)
+        shortname = re.search('(.+) (\(\d{4}\))', name.decode('utf-8')).group(1)
         urllang = [urllib.parse.urlencode({'seriesname': shortname, 'language': 'cs'}),
                    urllib.parse.urlencode({'seriesname': shortname, 'language': 'all'}),
                    urllib.parse.urlencode({'seriesname': name, 'language': 'cs'}),


### PR DESCRIPTION
This pull request addresses two main issues observed in the `plugin.video.sosac.ph` addon:

1. **Filename Normalization Issue**: 
   - The filename normalization logic was updated to ensure compatibility with Python 3. 
   - Previously, a `TypeError` was encountered because the code attempted to perform operations that expected a string type on an integer. 
   - The issue was resolved by adding appropriate decoding and encoding operations.

2. **TVDB String-Byte Issue**:
   - The `getTVDB` function was encountering a `TypeError` when attempting to use regular expressions on a bytes-like object.
   - This issue was fixed by ensuring that the input being processed by the regular expression functions is a string.
   - Necessary conversions were added to handle the transition between string and bytes objects seamlessly.

These changes enhance the robustness of the addon and ensure smooth operation with the latest versions of Kodi. 

Thank you for considering this pull request. I'm open to feedback and further suggestions.
